### PR TITLE
Rewrite documentation in `hardwaresystems/`

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Arm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Arm.java
@@ -81,10 +81,8 @@ public abstract class Arm {
     }
 
     /**
-     * Get all the {@link DcMotor}s that are included in this arm system.
-     *
-     * @return A {@link Set} that contains every {@link DcMotor} included in
-     * this arm system.
+     * {@return a {@link Set} that contains every {@link DcMotor} included in
+     * this arm system}
      */
     public Set<DcMotor> getMotors() {
         return MOTORS;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Claw.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Claw.java
@@ -186,7 +186,8 @@ public abstract class Claw {
     }
 
     /**
-     * Get all the {@link Servo}s that are included in this claw system.
+     * Get all the {@link Servo}s that are included in this {@link Claw}
+     * system.
      *
      * @return A {@link Set} that contains every {@code Claw} included in this
      * claw system.
@@ -201,17 +202,14 @@ public abstract class Claw {
      *
      * @return The number of motor ticks that the {@link Servo}s move with every
      * loop.
-     * @see #servoIncrement
      */
     public double getServoIncrement() {
         return servoIncrement;
     }
 
     /**
-     * Get the number of motor ticks that the {@link Servo}s move with every
+     * Set the number of motor ticks that the {@link Servo}s move with every
      * loop.
-     *
-     * @see #servoIncrement
      */
     public void setServoIncrement(double servoIncrement) {
         this.servoIncrement = servoIncrement;
@@ -221,10 +219,14 @@ public abstract class Claw {
      * Rotate the {@link #ROLL_SERVO} in a certain direction by
      * {@link Claw#servoIncrement}.
      *
-     * @param direction The direction to rotate the servo in, as seen from the
-     *                  <em>front</em> of the servo. Positive values rotate it
-     *                  counterclockwise, and negative values rotate it
-     *                  clockwise.
+     * @param direction The direction to rotate the servo in relative to
+     *                  {@link Servo#getDirection()}. As seen from the front of
+     *                  the {@link Servo}, positive values make the servo rotate
+     *                  in the direction of {@link Servo#getDirection()}, and
+     *                  negative values make the servo rotate in the opposite
+     *                  direction.
+     *                  <p>
+     *                  The magnitude has no effect.
      */
     public void rotateRollServo(double direction) {
         if (ROLL_SERVO != null) {
@@ -249,10 +251,14 @@ public abstract class Claw {
      * Rotate the {@link #PITCH_SERVO} in a certain direction by
      * {@link #servoIncrement}.
      *
-     * @param direction The direction to rotate the servo in, as seen from the
-     *                  <em>front</em> of the servo. Positive values rotate it
-     *                  counterclockwise, and negative values rotate it
-     *                  clockwise.
+     * @param direction The direction to rotate the servo in relative to
+     *                  {@link Servo#getDirection()}. As seen from the front of
+     *                  the {@link Servo}, positive values make the servo rotate
+     *                  in the direction of {@link Servo#getDirection()}, and
+     *                  negative values make the servo rotate in the opposite
+     *                  direction.
+     *                  <p>
+     *                  The magnitude has no effect.
      */
     public void rotatePitchAxisServo(double direction) {
         if (PITCH_SERVO != null) {
@@ -277,10 +283,14 @@ public abstract class Claw {
      * Rotate the {@link  #YAW_SERVO} in a certain direction by
      * {@link #servoIncrement}.
      *
-     * @param direction The direction to rotate the servo in, as seen from the
-     *                  <em>front</em> of the servo. Positive values rotate it
-     *                  counterclockwise, and negative values rotate it
-     *                  clockwise.
+     * @param direction The direction to rotate the servo in relative to
+     *                  {@link Servo#getDirection()}. As seen from the front of
+     *                  the {@link Servo}, positive values make the servo rotate
+     *                  in the direction of {@link Servo#getDirection()}, and
+     *                  negative values make the servo rotate in the opposite
+     *                  direction.
+     *                  <p>
+     *                  The magnitude has no effect.
      */
     public void rotateYawServo(double direction) {
         if (YAW_SERVO != null) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/DoubleServoIntakeClaw.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/DoubleServoIntakeClaw.java
@@ -135,8 +135,8 @@ public class DoubleServoIntakeClaw extends Claw {
         }
 
         /**
-         * Set the continuous rotation servo used to the left part of the intake
-         * (see {@link #LEFT_INTAKE_SERVO}).
+         * Set the continuous rotation servo that rotates the left part of the
+         * intake (see {@link #LEFT_INTAKE_SERVO}).
          *
          * @param leftIntakeServo The servo used to intake objects.
          * @return This {@link Builder} to allow for chaining setters.
@@ -147,8 +147,8 @@ public class DoubleServoIntakeClaw extends Claw {
         }
 
         /**
-         * Set the continuous rotation servo used to the left part of the intake
-         * (see {@link #LEFT_INTAKE_SERVO}).
+         * Set the continuous rotation servo that rotates the right part of the
+         * intake (see {@link #RIGHT_INTAKE_SERVO}).
          *
          * @param rightIntakeServo The servo used to intake objects.
          * @return This {@link Builder} to allow for chaining setters.
@@ -228,10 +228,9 @@ public class DoubleServoIntakeClaw extends Claw {
      *
      * @param builder The builder that contains the parameters to instantiate a
      *                new {@link SingleServoIntakeClaw} object.
-     * @throws IllegalArgumentException If either intake servo
-     *                                  ({@link Builder#leftIntakeServo} or
-     *                                  {@link Builder#rightIntakeServo}) is
-     *                                  {@code null}.
+     * @throws IllegalArgumentException If the given {@link Builder} object is
+     *                                  invalid as defined in
+     *                                  {@link Builder#isValid()}.
      */
     protected DoubleServoIntakeClaw(Builder builder) throws IllegalArgumentException {
         super(builder);
@@ -250,30 +249,24 @@ public class DoubleServoIntakeClaw extends Claw {
     }
 
     /**
-     * Get the power used to intake an object, i.e., pull it into the claw.
-     *
-     * @return The power used to intake an object, i.e., pull it into the claw.
+     * {@return the power used to intake an object, i.e., pull it into the
+     * claw}
      */
     public double getIntakePower() {
         return INTAKE_POWER;
     }
 
     /**
-     * Get the power used to eject an object, i.e., push it out of the claw.
-     *
-     * @return The power used to intake an object, i.e., push it out of the
-     * claw.
+     * {@return the power used to intake an object, i.e., push it out of the
+     * claw}
      */
     public double getEjectPower() {
         return EJECT_POWER;
     }
 
     /**
-     * Get all the continuous rotation servos ({@link CRServo}s) used by this
-     * {@link Claw}, i.e., the left and right intake servos.
-     *
-     * @return All the continuous rotation servos ({@link CRServo}s) used by
-     * this {@link Claw}, i.e., the left and right intake servos.
+     * {@return all the continuous rotation servos ({@link CRServo}s) used by
+     * this {@link Claw}, i.e., the left and right intake servos}
      */
     public Set<CRServo> getCrServos() {
         return new HashSet<>(Set.of(
@@ -283,29 +276,23 @@ public class DoubleServoIntakeClaw extends Claw {
     }
 
     /**
-     * Get the continuous rotation servo ({@link CRServo}) used to run the left
-     * intake.
-     *
-     * @return The continuous rotation servo ({@link CRServo}) used to run the
-     * left intake.
+     * {@return the continuous rotation servo ({@link CRServo}) used to rotate
+     * the left intake}
      */
     public CRServo getLeftIntakeServo() {
         return LEFT_INTAKE_SERVO;
     }
 
     /**
-     * Get the continuous rotation servo ({@link CRServo}) used to run the right
-     * intake.
-     *
-     * @return The continuous rotation servo ({@link CRServo}) used to run the
-     * right intake.
+     * {@return the continuous rotation servo ({@link CRServo}) used to rotate
+     * the right intake}.
      */
     public CRServo getRightIntakeServo() {
         return RIGHT_INTAKE_SERVO;
     }
 
     /**
-     * Spin both intake servos to pull in an object.
+     * Spin both continuous rotation servos to take in an object.
      */
     public void startIntake() {
         if (LEFT_INTAKE_SERVO != null) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/FoldingArm.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/FoldingArm.java
@@ -470,7 +470,8 @@ public class FoldingArm extends Arm {
      * Instantiate a foldable arm with a given {@link Builder} containing the
      * necessary parameters.
      *
-     * @throws IllegalArgumentException If the builder is invalid as defined by
+     * @throws IllegalArgumentException If the {@link Builder} object is invalid
+     *                                  as defined by
      *                                  {@link Builder#isValid()}.
      */
     protected FoldingArm(Builder builder) throws IllegalArgumentException {
@@ -505,36 +506,30 @@ public class FoldingArm extends Arm {
     }
 
     /**
-     * Get the {@link DcMotor} that is used to rotate the arm.
-     *
-     * @return The {@link DcMotor} that is used to rotate the arm.
+     * {@return the {@link DcMotor} that rotates the entire arm, like a shoulder
+     * with only one degree of freedom}
      */
     public DcMotor getRotationMotor() {
         return ROTATION_MOTOR;
     }
 
     /**
-     * Get the power multiplier that the arm motor rotates with.
-     *
-     * @return The power multiplier that the arm motor rotates with.
+     * {@return the maximum power that the rotation motor moves with, which is
+     * also a multiplier for the argument passed into {@link #rotate(double)}}
      */
-    public double getRotationPower() {
+    public double getMaxRotationPower() {
         return MAX_ROTATION_POWER;
     }
 
     /**
-     * Return the rotation position of the arm in motor ticks.
-     *
-     * @return The rotation position of the arm in motor ticks.
+     * {@return the rotation position of the arm in motor ticks}
      */
     public int getRotationTicks() {
         return ROTATION_MOTOR.getCurrentPosition();
     }
 
     /**
-     * Return the rotation position of the arm in degrees.
-     *
-     * @return The rotation angle of the arm in degrees.
+     * {@return the rotation angle of the arm in degrees}
      */
     public double getRotationDegrees() {
         return ROTATION_MOTOR.getCurrentPosition() / TICKS_PER_ROTATION_DEGREE
@@ -571,9 +566,13 @@ public class FoldingArm extends Arm {
      *                is 0 degrees.
      */
     public void rotateToAngle(double degrees) {
-        double targetDegrees = degrees - INITIAL_ROTATION_ANGLE;
-        int targetPosition = (int) -Math.round(targetDegrees
-                                               * TICKS_PER_ROTATION_DEGREE);
+        int targetPosition = (int) -Math.round(
+            (
+                degrees
+                - INITIAL_ROTATION_ANGLE
+            )
+            * TICKS_PER_ROTATION_DEGREE
+        );
         // Keep the target position within acceptable bounds
         targetPosition = Math.min(
             Math.max(targetPosition, MIN_ROTATION_TICKS),
@@ -583,7 +582,7 @@ public class FoldingArm extends Arm {
 
         /*
          * Calculate the direction that the arm will have to rotate.
-         * Negative is down, positive is up
+         * Negative is down, positive is up.
          */
         int direction = (int) Math.signum(
             targetPosition
@@ -595,36 +594,29 @@ public class FoldingArm extends Arm {
     }
 
     /**
-     * Get the {@link DcMotor} that is used to fold the arm.
-     *
-     * @return The {@link DcMotor} that is used to fold the arm.
+     * {@return the {@link DcMotor} that is used to fold the arm}
      */
     public DcMotor getFoldingMotor() {
         return FOLDING_MOTOR;
     }
 
     /**
-     * Get the power multiplier that the arm motor rotates with.
-     *
-     * @return The power multiplier that the arm motor rotates with.
+     * {@return the maximum power that the folding arm moves with, which is also
+     * a multiplier for the argument passed into {@link #fold(double)}}
      */
-    public double getFoldingPower() {
+    public double getMaxFoldingPower() {
         return MAX_FOLDING_POWER;
     }
 
     /**
-     * Get the current position of the folding motor in ticks.
-     *
-     * @return The current position of the folding motor in ticks.
+     * {@return the current position of the folding motor in ticks}
      */
     public int getFoldingTicks() {
         return FOLDING_MOTOR.getCurrentPosition();
     }
 
     /**
-     * Return the folding of the arm in degrees.
-     *
-     * @return A double representing the folding angle of the arm in degrees.
+     * {@return the folding angle of the arm in degrees}
      */
     public double getFoldingDegrees() {
         return FOLDING_MOTOR.getCurrentPosition() / TICKS_PER_FOLDING_DEGREE
@@ -658,17 +650,16 @@ public class FoldingArm extends Arm {
      * @param degrees The position to move the joint of the arm to in degrees.
      */
     public void foldToAngle(double degrees) {
-        double targetDegrees = degrees - INITIAL_FOLDING_ANGLE;
-        int targetPosition = (int) Math.round(
-            targetDegrees * TICKS_PER_FOLDING_DEGREE
-        );
-        // Keep the target position within acceptable bounds
+        int targetPosition = (int) Math.round((degrees - INITIAL_FOLDING_ANGLE)
+                                              * TICKS_PER_FOLDING_DEGREE);
+        // Keep the target position within acceptable bounds.
         targetPosition = -Math.min(
             Math.max(targetPosition, MIN_FOLDING_TICKS),
             MAX_FOLDING_TICKS
         );
         FOLDING_MOTOR.setTargetPosition(targetPosition);
 
+        // Move in the appropriate direction.
         int direction = (int) Math.signum(
             targetPosition
             - FOLDING_MOTOR.getCurrentPosition()

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/MecanumWheels.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/MecanumWheels.java
@@ -212,36 +212,28 @@ public class MecanumWheels extends Wheels {
     }
 
     /**
-     * Get the motor that drives the front-left mecanum wheel.
-     *
-     * @return The motor that drives the front-left mecanum wheel.
+     * {@return the motor that drives the front-left mecanum wheel}
      */
     public DcMotor getFrontLeftMotor() {
         return FRONT_LEFT_MOTOR;
     }
 
     /**
-     * Get the motor that drives the front-right mecanum wheel.
-     *
-     * @return The motor that drives the front-right mecanum wheel.
+     * {@return the motor that drives the front-right mecanum wheel}
      */
     public DcMotor getFrontRightMotor() {
         return FRONT_RIGHT_MOTOR;
     }
 
     /**
-     * Get the motor that drives the back-left mecanum wheel.
-     *
-     * @return The motor that drives the back-left mecanum wheel.
+     * {@return the motor that drives the back-left mecanum wheel}
      */
     public DcMotor getBackLeftMotor() {
         return BACK_LEFT_MOTOR;
     }
 
     /**
-     * Get the motor that drives the back-right mecanum wheel.
-     *
-     * @return The motor that drives the back-right mecanum wheel.
+     * {@return the motor that drives the back-right mecanum wheel}
      */
     public DcMotor getBackRightMotor() {
         return BACK_RIGHT_MOTOR;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/SingleServoIntakeClaw.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/SingleServoIntakeClaw.java
@@ -227,38 +227,29 @@ public class SingleServoIntakeClaw extends Claw {
     }
 
     /**
-     * Get the power that the {@link #INTAKE_SERVO} intakes with.
-     *
-     * @return The power that the {@link #INTAKE_SERVO} intakes with.
+     * {@return the power that the {@link #INTAKE_SERVO} takes in objects with}
      */
     public double getIntakePower() {
         return INTAKE_POWER;
     }
 
     /**
-     * Get the power that the {@link #INTAKE_SERVO} ejects with.
-     *
-     * @return The power that the {@link #INTAKE_SERVO} ejects with.
+     * {@return the power that the {@link #INTAKE_SERVO} ejects with}
      */
     public double getEjectPower() {
         return EJECT_POWER;
     }
 
     /**
-     * Get all the {@link CRServo}s used by this claw, which should just be the
-     * {@link #INTAKE_SERVO}.
-     *
-     * @return all the {@link CRServo}s used by this claw, which should just be
-     * the {@link #INTAKE_SERVO}.
+     * {@return all the {@link CRServo}s used by this claw, which should just be
+     * the {@link #INTAKE_SERVO}}
      */
     public Set<CRServo> getCrServos() {
         return new HashSet<>(Collections.singletonList(INTAKE_SERVO));
     }
 
     /**
-     * Get the intake servo, which draws objects into the claw.
-     *
-     * @return The intake servo, which draws objects into the claw.
+     * {@return the intake servo, which draws objects into the claw}
      */
     public CRServo getIntakeServo() {
         return INTAKE_SERVO;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Webcam.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Webcam.java
@@ -104,7 +104,7 @@ public class Webcam {
     /**
      * Processor that detects AprilTags in the camera image.
      */
-    private final AprilTagProcessor APRIL_TAG;
+    private final AprilTagProcessor APRIL_TAG_PROCESSOR;
     /**
      * Processor that finds the predominant color in a region of interest.
      */
@@ -178,7 +178,7 @@ public class Webcam {
         this.targetColor = null;
 
         // Create an AprilTag processor with default settings.
-        APRIL_TAG = new AprilTagProcessor.Builder().build();
+        APRIL_TAG_PROCESSOR = new AprilTagProcessor.Builder().build();
 
         // Create a predominant color processor with a center ROI and a set
         // of swatches.
@@ -199,7 +199,7 @@ public class Webcam {
         // are enabled.
         VisionPortal.Builder builder = new VisionPortal.Builder()
             .addProcessor(COLOR_PROCESSOR)
-            .addProcessor(APRIL_TAG)
+            .addProcessor(APRIL_TAG_PROCESSOR)
             .setCamera(webcamName)
             .setCameraResolution(new Size(resolution[0], resolution[1]))
             .setAutoStopLiveView(true);
@@ -209,69 +209,64 @@ public class Webcam {
     }
 
     /**
-     * Return the VisionPortal managing this webcam. You can use this to
-     * enable/disable processors or pause/resume the preview.
-     *
-     * @return The VisionPortal managing this webcam.
+     * {@return the {@link VisionPortal} managing this {@link Webcam}. You can
+     * use this to enable/disable processors or pause/resume the preview}
      */
     public VisionPortal getVisionPortal() {
         return VISION_PORTAL;
     }
 
     /**
-     * Return the AprilTag processor for this webcam.
-     *
-     * @return The AprilTag processor for this webcam.
+     * {@return the AprilTag processor for this webcam}
      */
     public AprilTagProcessor getAprilTag() {
-        return APRIL_TAG;
+        return APRIL_TAG_PROCESSOR;
     }
 
     /**
-     * Return a copy of the current AprilTag detections. The list may be empty
-     * if no tags are seen.
-     *
-     * @return A copy of the current AprilTag detections. The list may be empty
-     * if no tags are seen.
+     * {@return a copy of the current AprilTag detections. The list may be empty
+     * if no tags are seen}
      */
     public List<AprilTagDetection> getAprilTagDetections() {
         // Copy into a new list so callers cannot modify the internal list.
-        return new ArrayList<>(APRIL_TAG.getDetections());
+        return new ArrayList<>(APRIL_TAG_PROCESSOR.getDetections());
     }
 
     /**
-     * Return the predominant color processor. You can use this directly if you
-     * want to read more detailed color info.
-     *
-     * @return The predominant color processor.
+     * {@return the predominant color processor. You can use this directly if
+     * you want to read more detailed color info}
      */
     public PredominantColorProcessor getColorProcessor() {
         return COLOR_PROCESSOR;
     }
 
     /**
-     * Return the camera resolution.
-     *
-     * @return Return the camera resolution.
+     * {@return the camera resolution in the format [x, y]}
      */
     public int[] getResolution() {
         return RESOLUTION;
     }
 
     /**
-     * Tuning helper for AprilTags.
+     * Overload {@link #setAprilTagDecimation(float)}, with the decimation set
+     * to a default of {@code 2.0f}
      */
     public void setAprilTagDecimation() {
         setAprilTagDecimation(2.0f);
     }
 
     /**
-     * Tuning helper for AprilTags.
+     * Set the decimation parameter of the {@link #APRIL_TAG_PROCESSOR}, which
+     * controls how much the resolution should be downgraded. A lower value
+     * decreases the resolution, affecting the {@link #APRIL_TAG_PROCESSOR}'s
+     * ability to detect far away AprilTags but also increasing its frame rate.
      *
-     * @param decimation The frame rate to use.
+     * @param decimation The decimation parameter of the
+     *                   {@link #APRIL_TAG_PROCESSOR}, which controls how much
+     *                   the resolution should be downgraded.
      */
     public void setAprilTagDecimation(float decimation) {
-        APRIL_TAG.setDecimation(decimation);
+        APRIL_TAG_PROCESSOR.setDecimation(decimation);
     }
 
     /**
@@ -350,9 +345,8 @@ public class Webcam {
     }
 
     /**
-     * Return the current pose adjustment [x, y, z] for the camera.
-     *
-     * @return The current pose adjustment [x, y, z] for the camera.
+     * {@return the current pose adjustment for the camera in the format [x, y,
+     * z]}
      */
     public double[] getPoseAdjust() {
         return poseAdjust;
@@ -369,9 +363,8 @@ public class Webcam {
     }
 
     /**
-     * Return the currently selected target color (maybe {@code null}).
-     *
-     * @return The currently selected target color (maybe {@code null}).
+     * {@return the currently selected target color, which is possibly {@code
+     * null}}
      */
     public Color getTargetColor() {
         return targetColor;
@@ -387,11 +380,8 @@ public class Webcam {
     }
 
     /**
-     * Return the latest color analysis from the predominant color processor.
-     * May be null if no frame has been processed yet.
-     *
-     * @return The latest color analysis from the predominant color processor.
-     * May be {@code null} if no frame has been processed yet.
+     * {@return the latest color analysis from the predominant color processor.
+     * May be {@code null} if no frame has been processed yet}
      */
     public PredominantColorProcessor.Result getColorResult() {
         return COLOR_PROCESSOR.getAnalysis();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Wheels.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardwaresystems/Wheels.java
@@ -213,19 +213,15 @@ public abstract class Wheels {
     }
 
     /**
-     * Get the power that the motors drive with.
-     *
-     * @return The power that the motors drive with.
+     * {@return the power that the motors drive with}
      */
     public double getMotorPower() {
         return MAX_MOTOR_POWER;
     }
 
     /**
-     * Get all the {@link DcMotor}s that are used by this wheel system.
-     *
-     * @return A {@link Set} that contains every {@link DcMotor} included by
-     * this wheel system.
+     * {@return a {@link Set} that contains every {@link DcMotor} included by
+     * this wheel system}
      */
     public Set<DcMotor> getMotors() {
         return MOTORS;


### PR DESCRIPTION
Correct various typos in documentation from copying and pasting (e.g.,
forgetting to replace "left" with "right"), change all getter
documentation to use the {@return} tag to reduce redundancy, and rewrite
vague documentation to make it clearer.
